### PR TITLE
Report the screen size on the peak

### DIFF
--- a/drivers/video/msm/mipi_otm9608a_cmd_qhd_pt.c
+++ b/drivers/video/msm/mipi_otm9608a_cmd_qhd_pt.c
@@ -45,6 +45,8 @@ static int __init mipi_cmd_otm9608a_qhd_pt_init(void)
 
 	pinfo.xres = 540;
 	pinfo.yres = 960;
+	pinfo.width = 54;
+	pinfo.height = 95;
 	pinfo.type = MIPI_CMD_PANEL;
 	pinfo.pdest = DISPLAY_1;
 	pinfo.wait_cycle = 0;

--- a/drivers/video/msm/msm_fb.c
+++ b/drivers/video/msm/msm_fb.c
@@ -1133,8 +1133,10 @@ static int msm_fb_register(struct msm_fb_data_type *mfd)
 	var->grayscale = 0,	/* No graylevels */
 	var->nonstd = 0,	/* standard pixel format */
 	var->activate = FB_ACTIVATE_VBL,	/* activate it at vsync */
-	var->height = -1,	/* height of picture in mm */
-	var->width = -1,	/* width of picture in mm */
+	/* height of picture in mm */
+	var->height = panel_info->height ? panel_info->height : -1,
+	/* width of picture in mm */
+	var->width = panel_info->width ? panel_info->width : -1,
 	var->accel_flags = 0,	/* acceleration flags */
 	var->sync = 0,	/* see FB_SYNC_* */
 	var->rotate = 0,	/* angle we rotate counter clockwise */

--- a/drivers/video/msm/msm_fb_panel.h
+++ b/drivers/video/msm/msm_fb_panel.h
@@ -151,6 +151,8 @@ struct lvds_panel_info {
 struct msm_panel_info {
 	__u32 xres;
 	__u32 yres;
+	__u32 width;
+	__u32 height;
 	__u32 bpp;
 	__u32 mode2_xres;
 	__u32 mode2_yres;


### PR DESCRIPTION
This reports the screen size on the peak so gecko can get a proper dpi value. The dpi value is then used by gecko ( https://bugzilla.mozilla.org/show_bug.cgi?id=845182 ) to render things properly.

I used an online calculator to calculate the panel size - hopefully it's close enough.
